### PR TITLE
Added ability to accept regex for allowed origins in config file.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -21,10 +21,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handlePreflight(w, r)
 		w.WriteHeader(http.StatusOK)
 		return
-	} else {
-		h.handleRequest(w, r)
 	}
 
+	h.handleRequest(w, r)
 	h.next.ServeHTTP(w, r)
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -49,7 +49,7 @@ func (m *Middleware) originMatchesRegex(origin string) bool {
 		return false
 	}
 
-	for k, _ := range m.AllowedOrigins {
+	for k := range m.AllowedOrigins {
 		if re.MatchString(k) {
 			url := fmt.Sprintf("^%s$", re.FindStringSubmatch(k)[1])
 			match, _ := regexp.MatchString(url, origin)

--- a/middleware.go
+++ b/middleware.go
@@ -2,6 +2,7 @@ package cors
 
 import (
 	"fmt"
+	"regexp"
 
 	"net/http"
 )
@@ -35,6 +36,29 @@ func (m *Middleware) isOriginAllowed(origin string) bool {
 		return true
 	} else if m.AllowedOrigins[origin] != nil {
 		return true
+	} else if m.originMatchesRegex(origin) {
+		return true
+	}
+
+	return false
+}
+
+func (m *Middleware) originMatchesRegex(origin string) bool {
+	re, err := regexp.Compile("^/(.+)/$")
+	if err != nil {
+		return false
+	}
+
+	for k, _ := range m.AllowedOrigins {
+		if re.MatchString(k) {
+			url := fmt.Sprintf("^%s$", re.FindStringSubmatch(k)[1])
+			match, _ := regexp.MatchString(url, origin)
+
+			if match {
+				m.AllowedOrigins[origin] = m.AllowedOrigins[k]
+				return true
+			}
+		}
 	}
 
 	return false

--- a/test.yml
+++ b/test.yml
@@ -24,3 +24,8 @@ http://skookum.com:
     - "*"
   headers:
     - "*"
+/http://[a-z]+\.skookum\.com/:
+  methods:
+    - "*"
+  headers:
+    - "*"


### PR DESCRIPTION
This PR allows users to use regex to define the allowed origins.
## Features
- Origins must be wrapped between `//` to be interpreted as regex. 
- Example: `/https?://[a-z]+\.skookum\.com/`
- Any valid regular expression is accepted.
- Middleware will prepend `^` and append `$` to the regex origin with multiline mode **off**.
